### PR TITLE
DetectFileTypeCommand: Improve Windows compliancy

### DIFF
--- a/syntax_highlighting.py
+++ b/syntax_highlighting.py
@@ -27,5 +27,5 @@ class DetectFileTypeCommand(sublime_plugin.EventListener):
 def set_syntax(view, syntax, path=None):
   if path is None:
     path = syntax
-  view.settings().set('syntax', 'Packages/'+ path + '/' + syntax + '.tmLanguage')
+  view.set_syntax_file('Packages/' + path + '/' + syntax + '.tmLanguage')
   print "Switched syntax to: " + syntax


### PR DESCRIPTION
[Sublime API](http://www.sublimetext.com/docs/2/api_reference.html) recommends to rely on view.set_syntax_file(syntax_file) rather than view.settings().set('syntax', syntax_file).

Applying this change makes the syntax hightlighting switching works on Windows and makes the correct syntax being applied and ticked in the View->Syntax menu.
