### PR TITLE
Improve selection coloring + add find highlight support.

### DIFF
--- a/Railscasts.tmTheme
+++ b/Railscasts.tmTheme
@@ -20,7 +20,13 @@
 				<key>lineHighlight</key>
 				<string>#333435</string>
 				<key>selection</key>
-				<string>#5A647EE0</string>
+				<string>#444444</string>
+				<key>selectionBorder</key>
+				<string>#232323</string>
+				<key>findHighlight</key>
+				<string>#FFE792</string>
+				<key>findHighlightForeground</key>
+				<string>#000000</string>
 			</dict>
 		</dict>
 		<dict>


### PR DESCRIPTION
Hi Michael,

I thought I'd contribute back a minor update to your Railscasts.tmTheme. Gets rid of the out-of-place bluish highlight color and adds support for find highlighting.

![Screen Shot 2013-02-12 at 10 20 49 PM](https://f.cloud.github.com/assets/347072/151684/b5d27d14-758c-11e2-92bf-0789a65c8f2d.jpg)

Thanks for the superb project! Definitely helping round-out my skills.
