### PR TITLE
link subl in /usr/local/bin/

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,17 +4,11 @@ These are the steps needed to set up [Sublime Text 2](http://www.sublimetext.com
 
 ## Command-line command
 
-On OS X, you can set up `subl` as a command-line command by following the [Sublime Text&nbsp;2 instructions for the OS X command line](http://www.sublimetext.com/docs/2/osx_command_line.html):
+On OS X, you can set up `subl` as a command-line command like this:
 
-    $ ln -s "/Applications/Sublime Text 2.app/Contents/SharedSupport/bin/subl" ~/bin/subl
+    $ ln -s "/Applications/Sublime Text 2.app/Contents/SharedSupport/bin/subl" /usr/local/bin/subl 
 
-This assumes that `~/bin` is in your path. If isn't (which you can check using `echo $PATH` at the command line) you can put `subl` in `/usr/bin`:
-
-    $ sudo ln -s "/Applications/Sublime Text 2.app/Contents/SharedSupport/bin/subl" /usr/bin/subl
-
- Note the use of `sudo`, which is required because ordinary users don't have permission to write to `/usr/bin`. 
-
-On Linux (especially Ubuntu), the command is the same as for OS X; only the paths differ:
+On Linux (especially Ubuntu), the command is to OS X; the paths differ and you must use `sudo`, which is required because ordinary users don't have permission to write to `/usr/bin`. :
 
     $ sudo ln -s ~/Applications/Sublime\ Text\ 2/sublime_text /usr/bin/subl
 


### PR DESCRIPTION
sudo is not required, and it is in OS X's default PATH.
