### PR TITLE
add markdown syntax highlighting to themes

### DIFF
--- a/Railscasts (Light).tmTheme
+++ b/Railscasts (Light).tmTheme
@@ -277,6 +277,176 @@
 				<string>#D0CC54</string>
 			</dict>
 		</dict>
+		<dict>
+		    <key>name</key>
+		    <string>diff: deleted</string>
+		    <key>scope</key>
+		    <string>markup.deleted</string>
+		    <key>settings</key>
+		    <dict>
+		        <key>background</key>
+		        <string>#EAE3CA</string>
+		        <key>fontStyle</key>
+		        <string></string>
+		        <key>foreground</key>
+		        <string>#D3201F</string>
+		    </dict>
+		</dict>
+		<dict>
+		    <key>name</key>
+		    <string>diff: changed</string>
+		    <key>scope</key>
+		    <string>markup.changed</string>
+		    <key>settings</key>
+		    <dict>
+		        <key>background</key>
+		        <string>#EAE3CA</string>
+		        <key>fontStyle</key>
+		        <string></string>
+		        <key>foreground</key>
+		        <string>#BF3904</string>
+		    </dict>
+		</dict>
+		<dict>
+		    <key>name</key>
+		    <string>diff: inserted</string>
+		    <key>scope</key>
+		    <string>markup.inserted</string>
+		    <key>settings</key>
+		    <dict>
+		        <key>background</key>
+		        <string>#EAE3CA</string>
+		        <key>foreground</key>
+		        <string>#219186</string>
+		    </dict>
+		</dict>
+		<dict>
+		    <key>name</key>
+		    <string>Markdown: Linebreak</string>
+		    <key>scope</key>
+		    <string>text.html.markdown meta.dummy.line-break</string>
+		    <key>settings</key>
+		    <dict>
+		        <key>background</key>
+		        <string>#A57706</string>
+		        <key>foreground</key>
+		        <string>#E0EDDD</string>
+		    </dict>
+		</dict>
+		<dict>
+		    <key>name</key>
+		    <string>Markdown: Raw</string>
+		    <key>scope</key>
+		    <string>text.html.markdown markup.raw.inline</string>
+		    <key>settings</key>
+		    <dict>
+		        <key>foreground</key>
+		        <string>#269186</string>
+		    </dict>
+		</dict>
+		<dict>
+		    <key>name</key>
+		    <string>Markup: Heading</string>
+		    <key>scope</key>
+		    <string>markup.heading</string>
+		    <key>settings</key>
+		    <dict>
+		        <key>fontStyle</key>
+		        <string>bold</string>
+		        <key>foreground</key>
+		        <string>#cb4b16</string>
+		    </dict>
+		</dict>
+		<dict>
+		    <key>name</key>
+		    <string>Markup: Italic</string>
+		    <key>scope</key>
+		    <string>markup.italic</string>
+		    <key>settings</key>
+		    <dict>
+		        <key>fontStyle</key>
+		        <string>italic</string>
+		        <key>foreground</key>
+		        <string>#839496</string>
+		    </dict>
+
+		</dict>
+		<dict>
+		    <key>name</key>
+		    <string>Markup: Bold</string>
+		    <key>scope</key>
+		    <string>markup.bold</string>
+		    <key>settings</key>
+		    <dict>
+		        <key>fontStyle</key>
+		        <string>bold</string>
+		        <key>foreground</key>
+		        <string>#586e75</string>
+		    </dict>
+		</dict>
+		<dict>
+		    <key>name</key>
+		    <string>Markup: Underline</string>
+		    <key>scope</key>
+		    <string>markup.underline</string>
+		    <key>settings</key>
+		    <dict>
+		        <key>fontStyle</key>
+		        <string>underline</string>
+		        <key>foreground</key>
+		        <string>#839496</string>
+		    </dict>
+		</dict>
+		<dict>
+		    <key>name</key>
+		    <string>Markup: Quote</string>
+		    <key>scope</key>
+		    <string>markup.quote</string>
+		    <key>settings</key>
+		    <dict>
+		        <key>fontStyle</key>
+		        <string>italic</string>
+		        <key>foreground</key>
+		        <string>#268bd2</string>
+		    </dict>
+		</dict>
+		<dict>
+		    <key>name</key>
+		    <string>Markup: List</string>
+		    <key>scope</key>
+		    <string>markup.list</string>
+		    <key>settings</key>
+		    <dict>
+		        <key>foreground</key>
+		        <string>#657b83</string>
+		    </dict>
+		</dict>
+		<dict>
+		    <key>name</key>
+		    <string>Markup: Raw</string>
+		    <key>scope</key>
+		    <string>markup.raw</string>
+		    <key>settings</key>
+		    <dict>
+		        <key>foreground</key>
+		        <string>#b58900</string>
+		    </dict>
+		</dict>
+		<dict>
+		    <key>name</key>
+		    <string>Markup: Separator</string>
+		    <key>scope</key>
+		    <string>meta.separator</string>
+		    <key>settings</key>
+		    <dict>
+		        <key>background</key>
+		        <string>#eee8d5</string>
+		        <key>fontStyle</key>
+		        <string>bold</string>
+		        <key>foreground</key>
+		        <string>#268bd2</string>
+		    </dict>
+		</dict>
 	</array>
 	<key>uuid</key>
 	<string>B80CD0D8-613C-46FD-9C06-A1201108BC2A</string>

--- a/Railscasts.tmTheme
+++ b/Railscasts.tmTheme
@@ -277,6 +277,179 @@
 				<string>#2F33AB</string>
 			</dict>
 		</dict>
+
+		<dict>
+		    <key>name</key>
+		    <string>diff: deleted</string>
+		    <key>scope</key>
+		    <string>markup.deleted</string>
+		    <key>settings</key>
+		    <dict>
+		        <key>background</key>
+		        <string>#EAE3CA</string>
+		        <key>fontStyle</key>
+		        <string></string>
+		        <key>foreground</key>
+		        <string>#D3201F</string>
+		    </dict>
+		</dict>
+		<dict>
+		    <key>name</key>
+		    <string>diff: changed</string>
+		    <key>scope</key>
+		    <string>markup.changed</string>
+		    <key>settings</key>
+		    <dict>
+		        <key>background</key>
+		        <string>#EAE3CA</string>
+		        <key>fontStyle</key>
+		        <string></string>
+		        <key>foreground</key>
+		        <string>#BF3904</string>
+		    </dict>
+		</dict>
+		<dict>
+		    <key>name</key>
+		    <string>diff: inserted</string>
+		    <key>scope</key>
+		    <string>markup.inserted</string>
+		    <key>settings</key>
+		    <dict>
+		        <key>background</key>
+		        <string>#EAE3CA</string>
+		        <key>foreground</key>
+		        <string>#219186</string>
+		    </dict>
+		</dict>
+		<dict>
+		    <key>name</key>
+		    <string>Markdown: Linebreak</string>
+		    <key>scope</key>
+		    <string>text.html.markdown meta.dummy.line-break</string>
+		    <key>settings</key>
+		    <dict>
+		        <key>background</key>
+		        <string>#A57706</string>
+		        <key>foreground</key>
+		        <string>#E0EDDD</string>
+		    </dict>
+		</dict>
+		<dict>
+		    <key>name</key>
+		    <string>Markdown: Raw</string>
+		    <key>scope</key>
+		    <string>text.html.markdown markup.raw.inline</string>
+		    <key>settings</key>
+		    <dict>
+		        <key>foreground</key>
+		        <string>#269186</string>
+		    </dict>
+		</dict>
+		<dict>
+		    <key>name</key>
+		    <string>Markup: Heading</string>
+		    <key>scope</key>
+		    <string>markup.heading</string>
+		    <key>settings</key>
+		    <dict>
+		        <key>fontStyle</key>
+		        <string>bold</string>
+		        <key>foreground</key>
+		        <string>#cb4b16</string>
+		    </dict>
+		</dict>
+		<dict>
+		    <key>name</key>
+		    <string>Markup: Italic</string>
+		    <key>scope</key>
+		    <string>markup.italic</string>
+		    <key>settings</key>
+		    <dict>
+		        <key>fontStyle</key>
+		        <string>italic</string>
+		        <key>foreground</key>
+		        <string>#839496</string>
+		    </dict>
+
+		</dict>
+		<dict>
+		    <key>name</key>
+		    <string>Markup: Bold</string>
+		    <key>scope</key>
+		    <string>markup.bold</string>
+		    <key>settings</key>
+		    <dict>
+		        <key>fontStyle</key>
+		        <string>bold</string>
+		        <key>foreground</key>
+		        <string>#586e75</string>
+		    </dict>
+		</dict>
+		<dict>
+		    <key>name</key>
+		    <string>Markup: Underline</string>
+		    <key>scope</key>
+		    <string>markup.underline</string>
+		    <key>settings</key>
+		    <dict>
+		        <key>fontStyle</key>
+		        <string>underline</string>
+		        <key>foreground</key>
+		        <string>#839496</string>
+		    </dict>
+		</dict>
+		<dict>
+		    <key>name</key>
+		    <string>Markup: Quote</string>
+		    <key>scope</key>
+		    <string>markup.quote</string>
+		    <key>settings</key>
+		    <dict>
+		        <key>fontStyle</key>
+		        <string>italic</string>
+		        <key>foreground</key>
+		        <string>#268bd2</string>
+		    </dict>
+		</dict>
+		<dict>
+		    <key>name</key>
+		    <string>Markup: List</string>
+		    <key>scope</key>
+		    <string>markup.list</string>
+		    <key>settings</key>
+		    <dict>
+		        <key>foreground</key>
+		        <string>#657b83</string>
+		    </dict>
+		</dict>
+		<dict>
+		    <key>name</key>
+		    <string>Markup: Raw</string>
+		    <key>scope</key>
+		    <string>markup.raw</string>
+		    <key>settings</key>
+		    <dict>
+		        <key>foreground</key>
+		        <string>#b58900</string>
+		    </dict>
+		</dict>
+		<dict>
+		    <key>name</key>
+		    <string>Markup: Separator</string>
+		    <key>scope</key>
+		    <string>meta.separator</string>
+		    <key>settings</key>
+		    <dict>
+		        <key>background</key>
+		        <string>#eee8d5</string>
+		        <key>fontStyle</key>
+		        <string>bold</string>
+		        <key>foreground</key>
+		        <string>#268bd2</string>
+		    </dict>
+		</dict>
+
+
 	</array>
 	<key>uuid</key>
 	<string>B80CD0D8-613C-46FD-9C06-A1201108BC2A</string>


### PR DESCRIPTION
based on http://www.bram.us/2013/02/08/sublime-text-markdown-syntax-highlighting/
